### PR TITLE
Various bugfixes

### DIFF
--- a/sqlalchemy_sqlany/__init__.py
+++ b/sqlalchemy_sqlany/__init__.py
@@ -13,7 +13,7 @@ from .base import CHAR, VARCHAR, TIME, NCHAR, NVARCHAR,\
                  BIGINT, INT, INTEGER, SMALLINT, BINARY,\
                  VARBINARY, UNITEXT, UNICHAR, UNIVARCHAR,\
                  IMAGE, BIT, MONEY, SMALLMONEY, TINYINT,\
-                 dialect
+                 dialect, SQLAnyNoPrimaryKeyError
 
 
 __all__ = (
@@ -22,5 +22,5 @@ __all__ = (
     'BIGINT', 'INT', 'INTEGER', 'SMALLINT', 'BINARY',
     'VARBINARY', 'UNITEXT', 'UNICHAR', 'UNIVARCHAR',
     'IMAGE', 'BIT', 'MONEY', 'SMALLMONEY', 'TINYINT',
-    'dialect'
+    'dialect', "SQLAnyNoPrimaryKeyError"
 )

--- a/sqlalchemy_sqlany/base.py
+++ b/sqlalchemy_sqlany/base.py
@@ -15,7 +15,7 @@ from sqlalchemy.types import CHAR, VARCHAR, TIME, NCHAR, NVARCHAR,\
                             TEXT, DATE, DATETIME, FLOAT, NUMERIC,\
                             BIGINT, INT, INTEGER, SMALLINT, BINARY,\
                             VARBINARY, DECIMAL, TIMESTAMP, Unicode,\
-                            UnicodeText, REAL
+                            UnicodeText, REAL, LargeBinary
 
 RESERVED_WORDS = set([
     "add", "all", "alter", "and",
@@ -204,6 +204,7 @@ ischema_names = {
     'varbinary': VARBINARY,
     'image': IMAGE,
     'bit': BIT,
+    "long binary": LargeBinary,
 
 # not in documentation for ASE 15.7
     'long varchar': TEXT,  # TODO

--- a/sqlalchemy_sqlany/base.py
+++ b/sqlalchemy_sqlany/base.py
@@ -431,6 +431,10 @@ class SQLAnyDialect(default.DefaultDialect):
         return sqlanydb
 
     def create_connect_args(self, url):
+
+        # get extra options
+        dialect_opts = dict(url.query)
+
         opts = url.translate_connect_args(username='uid', password='pwd',
                                           database='dbn' )
         keys = list(opts.keys())
@@ -438,6 +442,7 @@ class SQLAnyDialect(default.DefaultDialect):
             opts['host'] += ':%s' % opts['port']
             del opts['port']
         #
+        opts.update(dialect_opts)
         return ([], opts)
     #
 

--- a/sqlalchemy_sqlany/base.py
+++ b/sqlalchemy_sqlany/base.py
@@ -235,8 +235,7 @@ ischema_names = {
 
 # converter function, only argument is the value returned
 # from the database that we want to convert
-_decimal_converter = lambda decAsString: decimal.Decimal(decAsString)
-   
+_decimal_converter = lambda decAsString: decimal.Decimal(decAsString) if decAsString is not None else None   
 
 # list of types to have converted, and the callable that sqlanydb calls when
 # it needs to convert said type

--- a/sqlalchemy_sqlany/base.py
+++ b/sqlalchemy_sqlany/base.py
@@ -90,12 +90,11 @@ class SQLAnyNoPrimaryKeyError(Exception):
     we just throw an exception and hopes the user adds primary keys to the table instead.
     '''
 
-    def __init__(self, tableName):
+    def __init__(self, message, table_name):
 
-        super(Exception, self).__init__(self)
+        super(SQLAnyNoPrimaryKeyError, self).__init__(message)
 
-        self.tableName = tableName
-
+        self.table_name = table_name
 
 class _SQLAnyUnitypeMixin(object):
     """these types appear to return a buffer object."""
@@ -710,7 +709,9 @@ class SQLAnyDialect(default.DefaultDialect):
         if not pks:
             # if we don't have any primary keys, then we will get a 
             # "TypeError: 'NoneType' object is not subscriptable" below.
-            raise SQLAnyNoPrimaryKeyError(table_name)
+            raise SQLAnyNoPrimaryKeyError(
+                "The table %s has no primary key and therefore can't be mapped using SQLAlchemy!" % table_name,
+                table_name)
 
         PKCOL_SQL = text("""
              select tc.column_name as col


### PR DESCRIPTION
4 fixes:

1: added a missing mapping for 'long binary' to the proper SQLAlchemy type
2: we now throw an exception when we try to load/reflect a table that has no primary keys rather then having a confusing "TypeError: none is not subscriptable"
3: Make it so the Dialect supports Decimal objects natively, so we avoid the scary warning from SQLAlchemy about not supporting them natively, and then having an exception "float is required" because the wrapper only returns strings for the Numeric/Decimal type, and SQLAlchemy needs a float or Decimal object.

Dec 4 2014:
Found another bug, since this wasn't pulled yet i'll add it here
4: Added support to pass in SQLAnywhere specific connection arguments using the URL class,
it wasn't returning in the params in URL.query in `SQLAnyDialect.create_connect_args()`, so passing anything in for URL(query=???) didn't do anything. Now you can pass in a dictionary into the query kwarg in the URL constructor and have it be passed to the sqlany api correctly. 