### PR TITLE
No constrained columns if no primary key

### DIFF
--- a/sqlalchemy_sqlany/base.py
+++ b/sqlalchemy_sqlany/base.py
@@ -665,7 +665,8 @@ class SQLAnyDialect(default.DefaultDialect):
         results = connection.execute(PK_SQL, table_id=table_id)
         pks = results.fetchone()
         results.close()
-
+        if not pks:
+            return {'constrained_columns':[],'name':''}
         PKCOL_SQL = text("""
              select tc.column_name as col
              FROM sys.sysidxcol ic


### PR DESCRIPTION
Hello,

We've been using this dialect for a few months on a project to read data from SQL Anywhere. The database is provided by a vendor, so we cannot modify it. They give us views which don't have primary keys. We found that, even though reflecting views is supported in SQLAlchemy, we could not reflect the database because of the lack of primary keys.

Adding this snippet seems to have fixed our issue. We've been running the integration for months now. I have no idea if this is correct, but it works! We're only reading, not writing to the database, so I couldn't say  what implications this might have for writing.

I hope it helps!

Regards,
Robert Conde