### PR TITLE
Added index_id in foreign key selection

### DIFF
--- a/sqlalchemy_sqlany/base.py
+++ b/sqlalchemy_sqlany/base.py
@@ -601,7 +601,7 @@ class SQLAnyDialect(default.DefaultDialect):
         column_cache[table_id] = columns
 
         REFCONSTRAINT_SQL = text("""
-          SELECT fk.foreign_index_id, i.index_name AS name, pt.table_id AS reftable_id
+          SELECT fk.foreign_index_id, i.index_name AS name, i.index_id, pt.table_id AS reftable_id
           FROM sys.sysfkey fk
           join sys.systab pt on fk.primary_table_id = pt.table_id
           join sys.sysidx i on i.table_id=fk.primary_table_id
@@ -619,6 +619,7 @@ class SQLAnyDialect(default.DefaultDialect):
 
         for r in referential_constraints:
             reftable_id = r["reftable_id"]
+            index_id = r["index_id"]
             foreign_index_id = r["foreign_index_id"]
 
             if reftable_id not in table_cache:
@@ -649,11 +650,13 @@ class SQLAnyDialect(default.DefaultDialect):
             join sys.sysidxcol ic on (fk.foreign_index_id=ic.index_id and fk.foreign_table_id=ic.table_id)
             join sys.sysidxcol pic on (fk.primary_index_id=pic.index_id and fk.primary_table_id=pic.table_id)
             WHERE fk.primary_table_id = :reftable_id
+            and fk.primary_index_id = :index_id
             and fk.foreign_table_id = :table_id
             and fk.foreign_index_id = :foreign_index_id
             """)
             ref_cols = connection.execute(REFCOLS_SQL,
                                           table_id=table_id,
+                                          index_id=index_id,
                                           reftable_id=reftable_id,
                                           foreign_index_id=foreign_index_id)
             for rc in ref_cols:


### PR DESCRIPTION
Apparently my previous pull request (which added foreign_index_id to the foreign key selection query) still isn't enough to prevent multiple foreign keys to become confused. This change seems to do the trick.